### PR TITLE
Deactivate coverage on object detection subfolder

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+# this is an import from tensorpack and the code is sadly not tested
+omit = *mot/object_detection/* 


### PR DESCRIPTION
It is deactivated because tensorpack never provided tests about it.
This repository isn't about object detection but multi-object-tracking helpers.